### PR TITLE
Add GHA CI and build fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+
+jobs:
+  build_test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['ubuntu-latest']
+        perl: [ '5' ]
+        thread: [ 'true' ]
+    name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl }}
+          multi-thread: ${{ matrix.thread }}
+      - run: perl -V
+      - name: install SWI-Prolog
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get install swi-prolog
+      - name: Install Perl deps
+        run: |
+          cpanm --verbose --notest --installdeps .
+      - name: Run tests
+        run: |
+          cpanm --verbose --test-only .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build_test:
     runs-on: ${{ matrix.os }}
+    env:
+      AUTHOR_TESTING: 1
     strategy:
       matrix:
         os: ['ubuntu-latest']
@@ -31,6 +33,9 @@ jobs:
       - name: Install Perl deps
         run: |
           cpanm --verbose --notest --installdeps .
+      - name: Install Perl author deps
+        run: |
+          cpanm --notest Test::Pod
       - name: Run tests
         run: |
           cpanm --verbose --test-only .

--- a/Low/Low.pm
+++ b/Low/Low.pm
@@ -67,6 +67,8 @@ sub init {
 1;
 __END__
 
+=encoding UTF-8
+
 =head1 NAME
 
 Language::Prolog::Yaswi::Low - Low level interface to SWI-Prolog

--- a/Low/Makefile.PL
+++ b/Low/Makefile.PL
@@ -16,11 +16,14 @@ else {
 
 my ($pl, @plvars);
 
+DUMP_RUNTIME_VARIABLES:
 for (@pl) {
     $pl = $_;
-    print "  running '$pl -dump-runtime-variables'\n";
-    @plvars=`$pl -dump-runtime-variables`;
-    $? or last;
+    for my $arg ( '--dump-runtime-variables', '-dump-runtime-variables' ) {
+        print "  running '$pl $arg'\n";
+        @plvars=`$pl $arg`;
+        $? or last DUMP_RUNTIME_VARIABLES;
+    }
 }
 if ($?) {
     print "unable to run swi-prolog: $?\nAborting...\n";

--- a/Low/swi2perl.c
+++ b/Low/swi2perl.c
@@ -32,10 +32,10 @@ SV *swi2perl(pTHX_ term_t t, AV *cells) {
 	return newSVnv(v);
     }
     case PL_STRING:
-    /*case PL_NIL:*/
     case PL_ATOM: {
         return swi2perl_atom_sv(aTHX_ t);
     }
+    case PL_NIL:
     case PL_LIST_PAIR: {
         AV *array=newAV();
         SV *ref=newRV_noinc((SV *)array);

--- a/Low/swi2perl.c
+++ b/Low/swi2perl.c
@@ -32,34 +32,34 @@ SV *swi2perl(pTHX_ term_t t, AV *cells) {
 	return newSVnv(v);
     }
     case PL_STRING:
+    /*case PL_NIL:*/
     case PL_ATOM: {
         return swi2perl_atom_sv(aTHX_ t);
     }
-    case PL_TERM: {
-        if (PL_is_list(t)) {
-            AV *array=newAV();
-            SV *ref=newRV_noinc((SV *)array);
-            int len=0;
-            term_t head, tail;
-            while(PL_is_list(t)) {
-                if(PL_get_nil(t)) {
-                    sv_bless(ref, gv_stashpv( len ?
-                                              TYPEINTPKG "::list" :
-                                              TYPEINTPKG "::nil", 1));
-                    return ref;
-                }
-                head=PL_new_term_refs(2);
-                tail=head+1;
-                PL_get_list(t, head, tail);
-                av_push(array, swi2perl(aTHX_ head, cells));
-                t=tail;
-                len++;
+    case PL_LIST_PAIR: {
+        AV *array=newAV();
+        SV *ref=newRV_noinc((SV *)array);
+        int len=0;
+        term_t head, tail;
+        while(PL_is_list(t)) {
+            if(PL_get_nil(t)) {
+                sv_bless(ref, gv_stashpv( len ?
+                                          TYPEINTPKG "::list" :
+                                          TYPEINTPKG "::nil", 1));
+                return ref;
             }
-            av_push(array, swi2perl(aTHX_ tail, cells));
-            sv_bless(ref, gv_stashpv(TYPEINTPKG "::ulist", 1));
-            return ref;
+            head=PL_new_term_refs(2);
+            tail=head+1;
+            PL_get_list(t, head, tail);
+            av_push(array, swi2perl(aTHX_ head, cells));
+            t=tail;
+            len++;
         }
-
+        av_push(array, swi2perl(aTHX_ tail, cells));
+        sv_bless(ref, gv_stashpv(TYPEINTPKG "::ulist", 1));
+        return ref;
+    }
+    case PL_TERM: {
         {
             /* any other compound */
             SV *ref;

--- a/t/4pods.t
+++ b/t/4pods.t
@@ -4,7 +4,7 @@ use strict;
 use Test::More;
 
 plan skip_all => "Only the author needs to check that POD docs are right"
-    unless eval "no warnings; getlogin eq 'salva'";
+    unless $ENV{AUTHOR_TESTING};
 
 eval "use Test::Pod 1.00";
 plan skip_all => "Test::Pod 1.00 required for testing POD" if $@;


### PR DESCRIPTION
- Add GitHub CI

  Build run: <https://github.com/zmughal/p5-Language-Prolog-Yaswi/runs/2126537083?check_suite_focus=true>

  Only runs on `ubuntu-latest` at this time. In the future, this can use [Homebrew](https://formulae.brew.sh/formula/swi-prolog) on macOS and [Chocolatey](https://chocolatey.org/packages/SWI-Prolog) on MSWin.
  
- Add support for `PL_LIST_PAIR` type:

  Incorporates patch by @ppisar from [RT#105114](https://rt.cpan.org/Public/Bug/Display.html?id=105114). This patch does not have support for the `PL_NIL` type as indicated by @ppisar on the RT tracker.
  
  According to <https://www.swi-prolog.org/pldoc/man?CAPI=PL_term_type>:
  
  > **Version 7** added `PL_NIL`, `PL_BLOB`, `PL_LIST_PAIR` and `PL_DICT`. Older versions classify `PL_NIL` and `PL_BLOB` as `PL_ATOM`, `PL_LIST_PAIR` as `PL_TERM` and do not have dicts. 
  
  - <https://github.com/SWI-Prolog/swipl-devel/blob/V7.6.4/man/foreign.doc>
  - <https://github.com/SWI-Prolog/swipl-devel/blob/V7.6.4/src/SWI-Prolog.h>
