### PR TITLE
Use Alien::SWIProlog for configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get pre-reqs for steps
         run: |
-          apt-get update && apt-get install -y build-essential xz-utils
+          apt-get update && apt-get install -y build-essential xz-utils curl cmake
+          # from <https://github.com/horta/zstd.install>
+          bash -c "$(curl -fsSL https://raw.githubusercontent.com/horta/zstd.install/main/install)"
       - name: Set up perl
         uses: shogo82148/actions-setup-perl@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,30 @@ jobs:
         os: ['ubuntu-latest']
         perl: [ '5.20', '5.34' ]
         thread: [ 'true', 'false' ]
+        include:
+          - { os: 'windows-latest', perl: '5', thread: true  }
+          - { os: 'macos-latest',   perl: '5', thread: false }
     name: Perl ${{ matrix.perl }},thr-${{ matrix.thread }} on ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
       - name: Set up perl
+        if: runner.os != 'Windows'
         uses: shogo82148/actions-setup-perl@v1
         with:
           perl-version: ${{ matrix.perl }}
           multi-thread: ${{ matrix.thread }}
+      - name: Set up perl
+        if: runner.os == 'Windows'
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl }}
+          distribution: 'strawberry'
+      - name: PERL_CPANM_HOME short path to avoid MAX_PATH
+        if: runner.os == 'Windows'
+        run: |
+          mkdir C:\tmp\.cpanm
+          echo "PERL_CPANM_HOME=C:/tmp/.cpanm" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - run: perl -V
       #- name: install SWI-Prolog
       #  if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
           perl-version: ${{ matrix.perl }}
           multi-thread: ${{ matrix.thread }}
       - run: perl -V
-      - name: install SWI-Prolog
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get install swi-prolog
+      #- name: install SWI-Prolog
+      #  if: matrix.os == 'ubuntu-latest'
+      #  run: |
+      #    sudo apt-get install swi-prolog
       - name: Install Perl deps
         run: |
           cpanm --notest --dev Alien::SWIProlog # configure requires

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           sudo apt-get install swi-prolog
       - name: Install Perl deps
         run: |
+          cpanm --notest --dev Alien::SWIProlog # configure requires
           cpanm --verbose --notest --installdeps .
       - name: Install Perl author deps
         run: |
@@ -77,6 +78,7 @@ jobs:
       - run: perl -V
       - name: Install Perl deps
         run: |
+          cpanm --notest --dev Alien::SWIProlog # configure requires
           cpanm --verbose --notest --installdeps .
       - name: Install Perl author deps
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,25 +58,46 @@ jobs:
           - swipl:8.0.3
           - swipl:8.1.0
           - swipl:8.1.15
-          #- swipl:8.1.30
-          #- swipl:8.2.4
-          #- swipl:8.3.29
-          #- swipl:8.4.0
-          #- swipl:stable
-    name: Perl ${{ matrix.perl }} with swipl container ${{ matrix.container }}
+          # The following containers have the conflicting symbol
+          # PL_version. See <https://github.com/salva/p5-Language-Prolog-Yaswi/issues/3>.
+          - swipl:8.1.30
+          - swipl:8.2.4
+          - swipl:8.3.29
+          - swipl:8.4.0
+          - swipl:stable
+        include:
+          # Include a version that would usually be a system install, but the
+          # threading of SWI-Prolog and Perl does not match so must build a share
+          # install.
+          - { perl: '5', thread: false, container: 'swipl:7.5.15' }
+    name: Perl ${{ matrix.perl }},thr-${{ matrix.thread }} with swipl container ${{ matrix.container }}
 
     steps:
       - uses: actions/checkout@v2
       - name: Get pre-reqs for steps
         run: |
-          apt-get update && apt-get install -y build-essential xz-utils curl cmake
-          # from <https://github.com/horta/zstd.install>
+          apt-get update && apt-get install -y build-essential xz-utils curl \
+            zlib1g-dev libarchive-dev libssl-dev openssl
+
+
+          # Install newer zstd needed for actions-setup-perl.
+          # From <https://github.com/horta/zstd.install>.
+          # This needs cmake.
+          apt-get install -y cmake
           bash -c "$(curl -fsSL https://raw.githubusercontent.com/horta/zstd.install/main/install)"
+
+          # Now uninstall cmake system package for the following steps since it
+          # is too old for building SWI-Prolog from source.  Will use
+          # Alien::cmake3 to get newer version.
+          apt-get remove -y cmake
       - name: Set up perl
         uses: shogo82148/actions-setup-perl@v1
         with:
           perl-version: ${{ matrix.perl }}
           multi-thread: ${{ matrix.thread }}
+      - name: Move openssl binary that is part of actions-setup-perl
+        run: |
+          which -a openssl | grep /hostedtoolcache/perl/ | xargs -I{} mv {} {}~
       - run: perl -V
       - name: Install Perl deps
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest']
-        perl: [ '5' ]
-        thread: [ 'true' ]
-    name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
+        perl: [ '5.20', '5.34' ]
+        thread: [ 'true', 'false' ]
+    name: Perl ${{ matrix.perl }},thr-${{ matrix.thread }} on ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2

--- a/Low/Low.pm
+++ b/Low/Low.pm
@@ -53,6 +53,7 @@ $dl_load_flags = 0x1 unless defined $dl_load_flags;
 sub dl_load_flags { $dl_load_flags }
 
 require DynaLoader;
+use Alien::SWIProlog;
 __PACKAGE__->bootstrap;
 
 our @args;

--- a/Low/Low.xs
+++ b/Low/Low.xs
@@ -21,6 +21,7 @@
 
 
 void savestate_Low(pTHX_ pMY_CXT) {
+    MY_dMY_CXT_accessor;
     save_item(c_depth);
     sv_inc(c_depth);
 }

--- a/Low/Makefile.PL
+++ b/Low/Makefile.PL
@@ -1,118 +1,13 @@
 use utf8;
 use ExtUtils::MakeMaker;
 use Config;
+use Alien::SWIProlog;
+use Alien::SWIProlog::Util;
 
 print "retrieving SWI-Prolog configuration:\n";
 
-my @pl;
-if (defined $ENV{PL}) {
-    @pl = $ENV{PL};
-}
-elsif ($^O =~ /Win32/) {
-    @pl = 'plcon.exe';
-}
-else {
-    @pl = qw(swipl swi-prolog pl);
-}
-
-my ($pl, @plvars);
-
-DUMP_RUNTIME_VARIABLES:
-for (@pl) {
-    $pl = $_;
-    for my $arg ( '--dump-runtime-variables', '-dump-runtime-variables' ) {
-        print "  running '$pl $arg'\n";
-        @plvars=`$pl $arg`;
-        $? or last DUMP_RUNTIME_VARIABLES;
-    }
-}
-if ($?) {
-    print "unable to run swi-prolog: $?\nAborting...\n";
-    exit(1);
-}
-
-my %plvar;
-foreach (@plvars) {
-    if (/^(PL.*?)="(.*)";$/) {
-	$plvar{$1}=$2;
-	print "    $1: $plvar{$1}\n";
-    }
-}
-
-my $swipl_version = $plvar{PLVERSION};
-
-$plvar{PLLIB} = '-lpl' unless defined $plvar{PLLIB};
-
-if ($^O=~/Win32/) {
-    $plvar{PLLIBS} = qq(-L"$plvar{PLBASE}/lib" $plvar{PLLIB} $plvar{PLLIBS});
-    $plvar{PLINC}  = qq(-I"$plvar{PLBASE}/include");
-    $plvar{PLEXE}  = qq($plvar{PLBASE}/bin/libpl.dll);
-    $plvar{PLPATH} = qq($plvar{PLBASE}/bin);
-}
-else {
-    if ($swipl_version >= 50400) {
-	$plvar{PLLIBS} = "$plvar{PLLIB} $plvar{PLLIBS}";
-	if ( $Config{myarchname} eq 'x86_64-linux' and
-	     $plvar{PLARCH} eq 'amd64' and
-	     $plvar{PLBASE} eq '/usr/lib/swi-prolog' and
-	     !-f "plvar{PLBASE}/lib/amd64/libpl.so" ) {
-	    print("\nDebian/Ubuntu amd64 SWI-Prolog package bug detected.\n",
-		  "Dynamic library not included under /usr/lib/swi-prolog/amd64/\n",
-		  "Trying to work around...\n\n");
-	}
-	else {
-	    $plvar{PLLIBS} ="-L$plvar{PLBASE}/lib/$plvar{PLARCH}/ $plvar{PLLIBS}";
-	}
-
-    }
-    else {
-	$plvar{PLLIBS}.=" -L$plvar{PLBASE}/runtime/$plvar{PLARCH}/";
-	$plvar{PLLIBS}.=($plvar{PLTHREADS} eq 'yes') ? ' -lplmt' : ' -lpl';
-    }
-
-    $plvar{PLINC}     = "-I$plvar{PLBASE}/include";
-    $plvar{PLPATH}    = "$plvar{PLBASE}/bin/$plvar{PLARCH}/";
-
-    if ($pl =~ m|/|) {
-        require File::Spec;
-        $plvar{PLEXE} = File::Spec->rel2abs($pl);
-    }
-    else {
-        $plvar{PLEXE} = $pl;
-    }
-
-
-}
-
-print "\nchecking thread support in Perl and SWI-Prolog:\n";
-if ($plvar{PLTHREADS}=~/y/) {
-    if ( !defined($Config::Config{usethreads}) ) {
-	print ("\nYour Perl doesn't support threads but your SWI-Prolog\n".
-	       "does, this configuration is not supported.\nAborting...\n");
-	exit(1);
-    }
-    if ( !defined($Config::Config{useithreads}) ) {
-	print ("\nThis package only supports interpreter threads (ithreads)\n".
-	       "and your Perl has been compiled with a different variety.\n".
-	       "Aborting...\n");
-	exit(1);
-    }
-    print "  thread support enabled\n";
-}
-else {
-    if (defined($Config::Config{useithreads}) ) {
-	print ("\nYour Perl support threads but your SWI-Prolog\n".
-	       "doesn't, this configuration is not supported.\nAborting...\n");
-	exit(1);
-    }
-    if (defined($Config::Config{usethreads})) {
-	print ("\nYou Perl has been compiled with an unsupported\n".
-	       "thread model and your SWI-Prolog doesn't support\n".
-	       "threads, this configuration is not supported.\nAborting...\n");
-	exit(1);
-    }
-    print "  thread support disabled\n";
-}
+$ENV{PL} = Alien::SWIProlog->runtime_prop->{'swipl-bin'};
+my $plvars = Alien::SWIProlog::Util::get_plvars( $ENV{PL} );
 
 print "\ncreating plconfig.c\n";
 unless (open (PLC, ">plconfig.c")) {
@@ -137,15 +32,14 @@ WriteMakefile( 'NAME' => 'Language::Prolog::Yaswi::Low',
                'PREREQ_PM' => {},
                'ABSTRACT_FROM' => 'Low.pm',
                'AUTHOR' => 'Salvador Fandiño <sfandino@yahoo.com>',
-               'LIBS' => [$plvar{PLLIBS}],
+               'LIBS' => [ Alien::SWIProlog->libs ],
                'DEFINE' => '',
-               'INC' => "-I. $plvar{PLINC}",
+               'INC' => Alien::SWIProlog->cflags,
                'OBJECT' => ( '$(BASEEXT)$(OBJ_EXT) callback$(OBJ_EXT) callperl$(OBJ_EXT)'.
                              ' hook$(OBJ_EXT) perl2swi$(OBJ_EXT) swi2perl$(OBJ_EXT)'.
                              ' plconfig$(OBJ_EXT) argv$(OBJ_EXT)'.
                              ' query$(OBJ_EXT) vars$(OBJ_EXT) context$(OBJ_EXT)'.
                              ' engines$(OBJ_EXT) opaque$(OBJ_EXT)' ),
-               'LDDLFLAGS' => "$Config{lddlflags} $plvar{PLLDFLAGS}",
                # 'OPTIMIZE' => '-g -O0'
              );
 

--- a/Low/context.c
+++ b/Low/context.c
@@ -8,6 +8,7 @@
 #include <SWI-Prolog.h>
 
 #include "Low.h"
+#define INSIDE_CONTEXT_C
 #include "context.h"
 
 
@@ -66,6 +67,10 @@ void release_cxt(pTHX_ pMY_CXT) {
 }
 
 my_cxt_t *get_MY_CXT(pTHX) {
+#ifndef MULTIPLICITY
+    return &my_cxt;
+#else
     dMY_CXT;
-    return my_cxtp;
+    return aMY_CXT;
+#endif
 }

--- a/Low/context.h
+++ b/Low/context.h
@@ -16,10 +16,6 @@ typedef struct {
     int prolog_init;
 } my_cxt_t;
 
-#ifndef MULTIPLICITY
-extern my_cxt_t my_cxt;
-#endif
-
 #define c_depth     MY_CXT.depth
 #define c_converter MY_CXT.converter
 #define c_qid       MY_CXT.qid
@@ -40,3 +36,20 @@ my_cxt_t *get_MY_CXT(pTHX);
 
 #define MY_dMY_CXT my_cxt_t *my_cxtp = get_MY_CXT(aTHX)
 
+/* MY_dMY_CXT_accessor
+ * ===================
+ * Use this macro to call accessor in functions that take `pMY_CXT` parameter.
+ * This is a no-op when `MULTIPLICITY` is defined.
+ */
+#ifndef INSIDE_CONTEXT_C
+#ifndef MULTIPLICITY
+#define MY_dMY_CXT_accessor MY_dMY_CXT
+/* MY_CXT is used in combination with MY_dMY_CXT_accessor.
+ *
+ * Redefine to using the pointer because the static variable is not visible.
+ */
+#define MY_CXT (*my_cxtp)
+#else
+#define MY_dMY_CXT_accessor dNOOP
+#endif /* MULTIPLICITY */
+#endif /*INSIDE_CONTEXT_C */

--- a/Low/engines.c
+++ b/Low/engines.c
@@ -13,6 +13,7 @@
 #include "engines.h"
 
 void check_prolog(pTHX_ pMY_CXT) {
+    MY_dMY_CXT_accessor;
     if (!c_prolog_ok) {
 	if(!PL_is_initialised(NULL, NULL)) {
 	    args2argv();
@@ -36,6 +37,7 @@ void check_prolog(pTHX_ pMY_CXT) {
 }
 
 void release_prolog(pTHX_ pMY_CXT) {
+    MY_dMY_CXT_accessor;
     if (c_prolog_ok && c_prolog_init) {
 #ifdef MULTIPLICITY
 	/* warn ("destroying Prolog engine"); */

--- a/Low/query.c
+++ b/Low/query.c
@@ -18,6 +18,7 @@
 
 
 void savestate_query(pTHX_ pMY_CXT) {
+    MY_dMY_CXT_accessor;
     save_item(c_qid);
     sv_setsv(c_qid, &PL_sv_undef);
     save_item(c_query);
@@ -25,6 +26,7 @@ void savestate_query(pTHX_ pMY_CXT) {
 }
 
 void close_query(pTHX_ pMY_CXT) {
+    MY_dMY_CXT_accessor;
     /* warn ("close_query(qid=%_)", qid); */
     PL_close_query(SvIV(c_qid));
     clear_vars(aTHX_ aMY_CXT);
@@ -34,22 +36,26 @@ void close_query(pTHX_ pMY_CXT) {
 }
 
 void test_no_query(pTHX_ pMY_CXT) {
+    MY_dMY_CXT_accessor;
     if(SvOK(c_qid)) {
 	croak ("there is already an open query on SWI-Prolog (qid=%s)", SvPV_nolen(c_qid));
     }
 }
 
 void test_query(pTHX_ pMY_CXT) {
+    MY_dMY_CXT_accessor;
     if(!SvOK(c_qid)) {
 	croak ("there is not any query open on SWI-Prolog");
     }
 }
 
 int is_query(pTHX_ pMY_CXT) {
+    MY_dMY_CXT_accessor;
     return SvOK(c_qid);
 }
 
 fid_t frame(pTHX_ pMY_CXT) {
+    MY_dMY_CXT_accessor;
     SV **w;
     int len=av_len(c_fids);
     if (len<0) {
@@ -63,12 +69,14 @@ fid_t frame(pTHX_ pMY_CXT) {
 }
 
 void push_frame(pTHX_ pMY_CXT) {
+    MY_dMY_CXT_accessor;
     SV *fid=newSViv(PL_open_foreign_frame());
     /* warn ("push_frame(%_)", fid); */
     av_push(c_fids, fid);
 }
 
 void pop_frame(pTHX_ pMY_CXT) {
+    MY_dMY_CXT_accessor;
     SV *fid=av_pop(c_fids);
     /* warn ("pop_frame(%_)", fid); */
     if (!SvOK(fid)) {
@@ -79,6 +87,7 @@ void pop_frame(pTHX_ pMY_CXT) {
 }
 
 void rewind_frame(pTHX_ pMY_CXT) {
+    MY_dMY_CXT_accessor;
     fid_t fid=frame(aTHX_ aMY_CXT);
     /* warn ("rewind_frame(%i)", fid); */
     PL_rewind_foreign_frame(fid);

--- a/Low/vars.c
+++ b/Low/vars.c
@@ -16,23 +16,27 @@
 
 
 AV *get_cells(pTHX_ pMY_CXT) {
+    MY_dMY_CXT_accessor;
     AV *av;
     if (av=GvAV(c_cells)) return av;
     return GvAV(c_cells)=newAV();
 }
 
 AV *get_vars(pTHX_ pMY_CXT) {
+    MY_dMY_CXT_accessor;
     AV *av;
     if (av=GvAV(c_vars)) return av;
     return GvAV(c_vars)=newAV();
 }
 
 HV *get_cache(pTHX_ pMY_CXT) {
+    MY_dMY_CXT_accessor;
     HV *hv;
     if (hv=GvHV(c_cache)) return hv;
     return GvHV(c_cache)=newHV();
 }
 void savestate_vars(pTHX_ pMY_CXT) {
+    MY_dMY_CXT_accessor;
     save_ary(c_vars);
     save_ary(c_cells);
     save_hash(c_cache);

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,15 +25,18 @@ $hash{META_MERGE} = {
 };
 
 WriteMakefile(
-    'NAME'		=> 'Language::Prolog::Yaswi',
-    'VERSION_FROM'	=> 'Yaswi.pm',
+    'NAME'              => 'Language::Prolog::Yaswi',
+    'VERSION_FROM'      => 'Yaswi.pm',
     CONFIGURE_REQUIRES  => {
-        'Alien::SWIProlog'           => '0',
+        'Alien::SWIProlog'        => '0',
     },
-    'PREREQ_PM'		=> { Language::Prolog::Types => '0.09',
-			     Language::Prolog::Sugar => '0.03', },
+    'PREREQ_PM'         => {
+        'Language::Prolog::Types' => '0.09',
+        'Language::Prolog::Sugar' => '0.03',
+        'Alien::SWIProlog'        => '0',
+    },
     TEST_REQUIRES => {
-        'Test::More'                 => '0',
+        'Test::More'              => '0',
     },
     'OPTIMIZE'          => '-g -O0',
     'ABSTRACT_FROM'     => 'Yaswi.pm',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -27,6 +27,9 @@ $hash{META_MERGE} = {
 WriteMakefile(
     'NAME'		=> 'Language::Prolog::Yaswi',
     'VERSION_FROM'	=> 'Yaswi.pm',
+    CONFIGURE_REQUIRES  => {
+        'Alien::SWIProlog'           => '0',
+    },
     'PREREQ_PM'		=> { Language::Prolog::Types => '0.09',
 			     Language::Prolog::Sugar => '0.03', },
     TEST_REQUIRES => {


### PR DESCRIPTION
- Use Alien::SWIProlog
- Test against SWI-Prolog versions with conflicting symbol
- Test different versions of Perl with and without threads
- Add windows and macos builds
- Update ppport.h using Devel::PPPort v3.63
- Use `static` instead of `extern` storage class for `my_cxt`

Fixes <https://github.com/salva/p5-Language-Prolog-Yaswi/issues/3>.